### PR TITLE
initial commit of netflix data, and code to unzip

### DIFF
--- a/Code/data-collection/netflix_data.py
+++ b/Code/data-collection/netflix_data.py
@@ -1,0 +1,15 @@
+import os
+import zipfile
+
+
+def default_progress_handler(percentage):
+    print('decompressing files: ' + str(percentage))
+
+
+def decompress(data_dir, progress_handler=default_progress_handler):
+    files = os.listdir(data_dir)
+    for i in range(0, len(files)):
+        if files[i].endswith('zip'):
+            with zipfile.ZipFile(data_dir + '/' + files[i], "r") as zip_ref:
+                zip_ref.extractall(data_dir)
+        progress_handler((i+1)/len(files)*100)

--- a/Data/netflix-prize/.gitattributes
+++ b/Data/netflix-prize/.gitattributes
@@ -1,0 +1,6 @@
+combined_data_1.txt.zip filter=lfs diff=lfs merge=lfs -text
+combined_data_2.txt.zip filter=lfs diff=lfs merge=lfs -text
+combined_data_3.txt.zip filter=lfs diff=lfs merge=lfs -text
+combined_data_4.txt.zip filter=lfs diff=lfs merge=lfs -text
+probe.txt.zip filter=lfs diff=lfs merge=lfs -text
+qualifying.txt.zip filter=lfs diff=lfs merge=lfs -text

--- a/Data/netflix-prize/combined_data_1.txt.zip
+++ b/Data/netflix-prize/combined_data_1.txt.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9fdfe7c5627a1ae64d69be5bad217a9eb8d4ef4be4226aeb375f1672a5d6d3e
+size 161258625

--- a/Data/netflix-prize/combined_data_2.txt.zip
+++ b/Data/netflix-prize/combined_data_2.txt.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96905d5c1765df80c731891781daa42ce894faf88d53e014acd4802a6c5280f8
+size 181261491

--- a/Data/netflix-prize/combined_data_3.txt.zip
+++ b/Data/netflix-prize/combined_data_3.txt.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e7368e86ba890ff9d21f70942b97e8ebc855e4a729a34a7a9e4e529d9881112
+size 151463579

--- a/Data/netflix-prize/combined_data_4.txt.zip
+++ b/Data/netflix-prize/combined_data_4.txt.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d3b306706655e801121fc50e72b51c48a12aaceeff1ebd2e32672c463b56b78
+size 179894739

--- a/Data/netflix-prize/probe.txt.zip
+++ b/Data/netflix-prize/probe.txt.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb237b5f85b1c26b836eacf83919465be6fe6f51887d05630f31aaf3e8fd5f24
+size 5219155

--- a/Data/netflix-prize/qualifying.txt.zip
+++ b/Data/netflix-prize/qualifying.txt.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adfbc932389f7de2fa78caabf5e2ea7af8197481332733f6f14abc0636ff48c7
+size 17447936


### PR DESCRIPTION
  attempted to reduce this by having a download from kaggle
  mechanism, but experienced some issues trying to set that up.

  Netflix has a binary file content size limit of 100 MB, these files do exceed that. 
  I've decided to setup git lfs support for the time being. We'll need to confirm that priyanka and amir are on board with us utilizing this option, as it's not strictly a 'git' feature, though github started supporting the added functionality sometime in the last 2 or 3 years (afaik)