### PR TITLE
moved the driver.py script up a directory

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -4,7 +4,7 @@ import sys
 import os
 from PyQt5.QtWidgets import QApplication
 
-from gui.DEMO import DEMO
+from Code.gui.DEMO import DEMO
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)


### PR DESCRIPTION
Moving it up a directory means pycharm doesn't need to modify the PYTHON_PATH variable as much. Which will help avoid the hassle of complicated configuration issues... just `python driver.py` should work at that point.